### PR TITLE
Improve search display

### DIFF
--- a/lib/jekyll_build_search.rb
+++ b/lib/jekyll_build_search.rb
@@ -13,7 +13,7 @@ module Jekyll
       converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
       search_list = []
 
-      site.posts.docs.each do |post|
+      site.posts.docs.reverse_each do |post|
         search_list.push(*build_post_hashes(post, converter))
       end
 

--- a/lib/jekyll_build_search.rb
+++ b/lib/jekyll_build_search.rb
@@ -49,7 +49,7 @@ module Jekyll
         date = DateTime.parse(line.strip)
         yearmonth = date.strftime("%Y_%m")
         iddate = date.strftime("%Y%m%d")
-        displaydate = date.strftime("%a, %b %e")
+        displaydate = date.strftime("%b %e, %Y")
 
         # we've found a new entry, remove it from the previous entry's lines
         curr_hash["content"].pop()


### PR DESCRIPTION
This fixes some annoyances with searching on multi-year ELNs.

1. Search results now display year
2. Search results are now sorted so that the newest entries are first